### PR TITLE
Update: Add pip-based installation guide and Ubuntu 24.04 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Piper_isaac_sim
 
-测试系统配置：ubuntu22.04+4060显卡
+测试系统配置：
+- Ubuntu 20.04 / 22.04 / 24.04
+- Python 3.10
+- NVIDIA RTX 系列显卡（Driver 535+）
 
-**NOTE:当前模型没有颜色**
+**NOTE: 当前模型没有颜色**
 
 ## 1、配置系统环境
 
@@ -10,36 +13,64 @@
 
 [下载链接](https://www.nvidia.com/Download/index.aspx)
 
-### 2）下载NVIDIA Omniverse
+请确保已安装适合您显卡的 NVIDIA 驱动程序（建议版本 535 或更高）。
 
-[下载链接](https://www.nvidia.com/en-us/omniverse/)
+### 2）配置 Python 环境
 
-### 3）下载isaac sim
+建议使用 Python 虚拟环境（Anaconda/Miniconda 或 Pyenv），并推荐 **Python 3.10**。
 
-> 安装isaac sim之前，可以使用ISAAC SIM COMPATIBILITY CHECKER检查一下，电脑配置是否满足要求
-
-在Omniverse里面下载isaac sim
-
-![](./img/isaac_1.png)
-
-下载完成之后可以启动isaac sim
-
-![](img/isacc_4.png)
-
-### 下载代码
-
-```
-https://github.com/agilexrobotics/piper_isaac_sim.git
+```bash
+# 使用 Conda 创建环境示例
+conda create -n isaac_sim python=3.10
+conda activate isaac_sim
 ```
 
-### 4）启动isaac sim，导入USD
+### 3）安装 Isaac Sim（Pip 方式）
 
-![](img/isacc_4.png)
+由于 Omniverse Launcher 的安装方式已逐渐被弃用，建议使用 Python 环境直接通过 `pip` 安装 Isaac Sim 相关组件。
 
-![](img/isaac_2.png)
+对于 Ubuntu 24.04 用户，建议显式安装以下组件以确保兼容性。
 
-打开isacc sim之后，在content中找到存放USD的路径，双击打开
+```bash
+# 更新 pip
+pip install --upgrade pip
 
-![](img/isaac_3.png)
+# 安装 Isaac Sim 核心组件
+# 注意：下载文件较大，请确保网络连接畅通
+pip install isaacsim-robot isaacsim-gui isaacsim-utils isaacsim-sensor \
+  --extra-index-url https://pypi.nvidia.com
+```
 
-成功导入后，点击三角按钮开始仿真
+### 4）下载代码并安装依赖
+
+下载本仓库代码并安装其余依赖项：
+
+```bash
+git clone https://github.com/agilexrobotics/piper_isaac_sim.git
+cd piper_isaac_sim
+
+# 安装项目依赖
+pip install -r requirements.txt
+```
+
+## 2、启动仿真
+
+### 1）运行 Isaac Sim
+
+本项目提供了启动脚本 `launch_sim.py`，直接运行即可启动仿真器：
+
+```bash
+python launch_sim.py
+```
+
+注意：首次运行时，Isaac Sim 需要编译着色器（RTX Shaders），可能会出现几分钟的黑屏或长时间加载，请耐心等待。
+
+### 2）导入 USD 模型
+
+仿真器启动并出现窗口后：
+
+1. 在菜单栏点击 `File > Open`。
+2. 找到本项目路径下的 `usd` 文件夹。
+3. 选择 `piper_description.usd`（或 `piper.usd`）并打开。
+4. 成功导入后，点击左侧工具栏的 `Play`（三角按钮）开始仿真。
+

--- a/launch_sim.py
+++ b/launch_sim.py
@@ -1,0 +1,13 @@
+# launch_sim.py
+from isaacsim import SimulationApp
+
+# 設定
+config = {"headless": False}
+simulation_app = SimulationApp(config)
+
+print("Isaac Sim is running...")
+
+while simulation_app.is_running():
+    simulation_app.update()
+
+simulation_app.close()


### PR DESCRIPTION
## Motivation
Since the Omniverse Launcher is being deprecated and is difficult to use on newer OS versions, I have updated the installation instructions to use the standard Python `pip` workflow.

## Changes
- Updated `README.md` to reflect the `pip install` method instead of the Launcher method.
- Added `launch_sim.py` to launch Isaac Sim directly from the terminal.
- Verified functionality on **Ubuntu 24.04** with NVIDIA Driver 535+.

## How to Run
1. Install dependencies via pip.
2. Run `python launch_sim.py`.
3. Load the USD file manually.